### PR TITLE
Add Hydra configuration example

### DIFF
--- a/tutorials/hydra_basics/config.yaml
+++ b/tutorials/hydra_basics/config.yaml
@@ -1,0 +1,16 @@
+# Basic Hydra configuration example
+
+# These are our application parameters
+app:
+  name: "My Simulation"
+  version: 1.0
+
+# Simulation parameters  
+simulation:
+  n_steps: 100
+  seed: 42
+
+# Data parameters
+data:
+  input_file: "data/input.csv"
+  output_dir: "results"


### PR DESCRIPTION
## Summary
- add a basic Hydra configuration example for tutorials

## Testing
- `flake8 src tests`
- `mypy src`
- `python tests/run_tests.py`
- `pytest -q tests/test_log_wrappers.py`


------
https://chatgpt.com/codex/tasks/task_e_684f1d9fe4cc832b8da2e19693037598