### PR TITLE
Add Hydra project skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ from pop_ml_sim import SimulationFramework
 from pop_ml_sim.config import load_config
 
 # Load configuration
-config = load_config("configs/basic_simulation.yaml")
+config = load_config()
 
 # Initialize framework
 sim = SimulationFramework(config)

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,0 +1,10 @@
+defaults:
+  - population: medium
+  - hospitals: basic
+  - simulation: short
+  - hazards: standard
+
+experiment:
+  name: "phase1_baseline"
+  seed: 42
+  output_dir: "outputs"

--- a/configs/hazards/low_risk.yaml
+++ b/configs/hazards/low_risk.yaml
@@ -1,0 +1,3 @@
+annual_incident_rate: 0.005
+base_mortality_hazard: 0.001
+incident_mortality_multiplier: 1.1

--- a/configs/hazards/standard.yaml
+++ b/configs/hazards/standard.yaml
@@ -1,0 +1,3 @@
+annual_incident_rate: 0.015
+base_mortality_hazard: 0.001
+incident_mortality_multiplier: 1.3

--- a/configs/hospitals/basic.yaml
+++ b/configs/hospitals/basic.yaml
@@ -1,0 +1,8 @@
+n_hospitals: 5
+size_distribution:
+  small: 0.6
+  medium: 0.3
+  large: 0.1
+quality_range:
+  min: 0.5
+  max: 0.9

--- a/configs/hospitals/extended.yaml
+++ b/configs/hospitals/extended.yaml
@@ -1,0 +1,8 @@
+n_hospitals: 15
+size_distribution:
+  small: 0.4
+  medium: 0.4
+  large: 0.2
+quality_range:
+  min: 0.4
+  max: 0.95

--- a/configs/population/large.yaml
+++ b/configs/population/large.yaml
@@ -1,0 +1,4 @@
+n_persons: 100000
+age_min: 18
+age_max: 90
+random_seed: 1

--- a/configs/population/medium.yaml
+++ b/configs/population/medium.yaml
@@ -1,0 +1,4 @@
+n_persons: 10000
+age_min: 18
+age_max: 90
+random_seed: 1

--- a/configs/population/small.yaml
+++ b/configs/population/small.yaml
@@ -1,0 +1,4 @@
+n_persons: 1000
+age_min: 18
+age_max: 90
+random_seed: 1

--- a/configs/simulation/long.yaml
+++ b/configs/simulation/long.yaml
@@ -1,0 +1,3 @@
+total_months: 48
+delta_t: 1.0
+checkpoint_frequency: 12

--- a/configs/simulation/short.yaml
+++ b/configs/simulation/short.yaml
@@ -1,0 +1,3 @@
+total_months: 12
+delta_t: 1.0
+checkpoint_frequency: 3

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+
+[project]
+name = "pop-ml-simulator"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = [
+    "hydra-core>=1.3.0",
+    "omegaconf>=2.3.0",
+]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,6 @@
+"""pop-ml-simulator core package."""
+
+from .config import load_config
+from .core.temporal_engine import TemporalEngine
+
+__all__ = ["load_config", "TemporalEngine"]

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from typing import List
+
+from hydra import compose, initialize_config_dir
+from omegaconf import DictConfig
+
+from src.utils.logging import log_call
+from src.utils.validation import validate_config
+
+CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs"
+
+
+@log_call
+def load_config(overrides: List[str] | None = None) -> DictConfig:
+    """Load and validate a configuration using Hydra."""
+
+    overrides = overrides or []
+    with initialize_config_dir(
+        CONFIG_DIR.resolve().as_posix(), version_base=None
+    ):
+        cfg = compose(config_name="config", overrides=overrides)
+    validate_config(cfg)
+    return cfg

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from hydra import compose, initialize_config_dir
 from omegaconf import DictConfig
@@ -11,7 +11,7 @@ CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs"
 
 
 @log_call
-def load_config(overrides: List[str] | None = None) -> DictConfig:
+def load_config(overrides: Optional[List[str]] = None) -> DictConfig:
     """Load and validate a configuration using Hydra."""
 
     overrides = overrides or []

--- a/src/config/schemas.py
+++ b/src/config/schemas.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class PopulationConfig:
+    n_persons: int
+    age_min: int
+    age_max: int
+    random_seed: int
+
+
+@dataclass
+class HospitalConfig:
+    n_hospitals: int
+    size_distribution: Dict[str, float]
+    quality_range: Dict[str, float]
+
+
+@dataclass
+class SimulationConfig:
+    total_months: int
+    delta_t: float = 1.0
+    checkpoint_frequency: int = 1
+
+
+@dataclass
+class HazardsConfig:
+    annual_incident_rate: float
+    base_mortality_hazard: float
+    incident_mortality_multiplier: float
+
+
+@dataclass
+class ExperimentConfig:
+    name: str
+    seed: int
+    output_dir: str

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,6 @@
+"""Core simulation modules."""
+
+from .data_structures import Population, Patient
+from .temporal_engine import TemporalEngine
+
+__all__ = ["Population", "Patient", "TemporalEngine"]

--- a/src/core/data_structures.py
+++ b/src/core/data_structures.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass, field
+from random import Random
+from typing import List
+
+from src.utils.logging import log_call
+
+
+@dataclass
+class Patient:
+    age: int
+
+
+@dataclass
+class Population:
+    n_persons: int
+    age_min: int
+    age_max: int
+    random_seed: int
+    persons: List[Patient] = field(init=False)
+
+    @log_call
+    def __post_init__(self) -> None:
+        rnd = Random(self.random_seed)
+        self.persons = [
+            Patient(age=rnd.randint(self.age_min, self.age_max))
+            for _ in range(self.n_persons)
+        ]

--- a/src/core/temporal_engine.py
+++ b/src/core/temporal_engine.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+from omegaconf import DictConfig
+
+from src.utils.logging import log_call
+
+
+@dataclass
+class TemporalEngine:
+    cfg: DictConfig
+
+    @log_call
+    def run(self) -> None:
+        """Placeholder run method."""
+        months = self.cfg.simulation.total_months
+        for _ in range(months):
+            pass

--- a/src/pop_ml_simulator/sample.py
+++ b/src/pop_ml_simulator/sample.py
@@ -1,4 +1,4 @@
-from utils.logging import log_call
+from src.utils.logging import log_call
 
 
 @log_call

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,4 @@
+from .logging import log_call
+from .validation import validate_config
+
+__all__ = ["log_call", "validate_config"]

--- a/src/utils/validation.py
+++ b/src/utils/validation.py
@@ -1,0 +1,17 @@
+from omegaconf import DictConfig
+
+from src.utils.logging import log_call
+
+
+@log_call
+def validate_config(cfg: DictConfig) -> None:
+    """Simple validation for simulation configs."""
+
+    if cfg.population.n_persons <= 0:
+        raise ValueError("n_persons must be positive")
+    if cfg.population.age_min >= cfg.population.age_max:
+        raise ValueError("age_min must be less than age_max")
+    if cfg.hospitals.n_hospitals <= 0:
+        raise ValueError("n_hospitals must be positive")
+    if not 0 <= cfg.hazards.annual_incident_rate <= 1:
+        raise ValueError("annual_incident_rate must be between 0 and 1")

--- a/tests/fixtures/sample_configs.py
+++ b/tests/fixtures/sample_configs.py
@@ -1,0 +1,32 @@
+from omegaconf import OmegaConf
+
+
+def make_invalid_config() -> OmegaConf:
+    """Return a config with invalid population size."""
+
+    cfg = OmegaConf.create(
+        {
+            "population": {
+                "n_persons": -1,
+                "age_min": 10,
+                "age_max": 20,
+                "random_seed": 1,
+            },
+            "hospitals": {
+                "n_hospitals": 1,
+                "size_distribution": {"small": 1.0},
+                "quality_range": {"min": 0.5, "max": 0.9},
+            },
+            "simulation": {
+                "total_months": 1,
+                "delta_t": 1.0,
+                "checkpoint_frequency": 1,
+            },
+            "hazards": {
+                "annual_incident_rate": 0.01,
+                "base_mortality_hazard": 0.001,
+                "incident_mortality_multiplier": 1.0,
+            },
+        }
+    )
+    return cfg

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,35 @@
+from itertools import product
+
+import pytest
+
+from src.config import load_config
+from src.utils.validation import validate_config
+from tests.fixtures.sample_configs import make_invalid_config
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        [
+            f"population={p}",
+            f"hospitals={h}",
+            f"simulation={s}",
+            f"hazards={z}",
+        ]
+        for p, h, s, z in product(
+            ["small", "medium", "large"],
+            ["basic", "extended"],
+            ["short", "long"],
+            ["low_risk", "standard"],
+        )
+    ],
+)
+def test_all_configs_load(overrides):
+    cfg = load_config(overrides)
+    assert cfg is not None
+
+
+def test_validation_fails_on_invalid():
+    cfg = make_invalid_config()
+    with pytest.raises(ValueError):
+        validate_config(cfg)

--- a/tests/test_data_structures.py
+++ b/tests/test_data_structures.py
@@ -1,0 +1,7 @@
+from src.core.data_structures import Population
+
+
+def test_population_generation():
+    pop = Population(n_persons=10, age_min=0, age_max=100, random_seed=1)
+    assert len(pop.persons) == 10
+    assert all(0 <= p.age <= 100 for p in pop.persons)


### PR DESCRIPTION
## Summary
- integrate Hydra configuration system with default YAML files
- add dataclass schemas for configs and base temporal engine
- implement simple population generation
- provide validation utilities and unit tests
- fix imports for package modules

## Testing
- `flake8 src tests`
- `mypy src`
- `python tests/run_tests.py`
- `pytest -q tests/test_log_wrappers.py`


------
https://chatgpt.com/codex/tasks/task_e_684f2eb1bd44832b9940e41771fa6d9c