### PR TITLE
Update CI Python version

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.13.5'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- run CI tests with Python 3.13.5

## Testing
- `flake8 src tests`
- `mypy src`
- `python tests/run_tests.py`
- `pytest -q tests/test_log_wrappers.py`


------
https://chatgpt.com/codex/tasks/task_e_684f3cd2ff7c832b98f3475eb862e51b