### PR TITLE
Remove redundant 'integration_method' parameter from ML simulation (Issue #51)

### DIFF
--- a/src/pop_ml_simulator/ml_simulation.py
+++ b/src/pop_ml_simulator/ml_simulation.py
@@ -437,7 +437,6 @@ class MLPredictionSimulator:
         # Calculate temporal correlation metrics
         n_patients, n_timesteps = temporal_risk_matrix.shape
         integration_info = {
-            'integration_method': 'survival',
             'window_start': prediction_start_time,
             'window_length': prediction_window_length,
             'mean_integrated_risk': float(np.mean(integrated_risks)),
@@ -755,7 +754,8 @@ def generate_temporal_ml_predictions(
     random_seed: Optional[int] = None
 ) -> Tuple[np.ndarray, np.ndarray, Dict[str, object]]:
     """
-    Generate ML predictions using integrated temporal window risks.
+    Generate ML predictions using survival-based integration of temporal window
+    risks.
 
     This function represents the core temporal-aware ML prediction approach
     that integrates risk trajectories over prediction windows instead of
@@ -857,7 +857,8 @@ def generate_temporal_ml_predictions(
         true_labels, integrated_risks, n_iterations=15
     )
 
-    # Generate ML predictions using integrated temporal risks
+    # Generate ML predictions using survival-based integration of temporal
+    # risks
     predictions, binary_predictions = ml_simulator.generate_predictions(
         true_labels,
         integrated_risks,
@@ -900,7 +901,6 @@ def generate_temporal_ml_predictions(
         'temporal_correlation': temporal_correlation,
         'integrated_risk_correlation': integrated_correlation,
         'mean_integrated_risk': float(np.mean(integrated_risks)),
-        'integration_method': 'survival',
         'window_length': prediction_window_length,
         'optimization_correlation': optimization_params['correlation'],
         'optimization_scale': optimization_params['scale']
@@ -1108,7 +1108,6 @@ def benchmark_temporal_ml_performance(
                 'config_id': config_id,
                 'start_time': config['start_time'],
                 'window_length': config['window_length'],
-                'integration_method': 'survival',
                 'temporal_sensitivity': temporal_metrics['sensitivity'],
                 'temporal_ppv': temporal_metrics['ppv'],
                 'temporal_f1': temporal_metrics['f1'],
@@ -1136,7 +1135,6 @@ def benchmark_temporal_ml_performance(
                 'config_id': config_id,
                 'start_time': config['start_time'],
                 'window_length': config['window_length'],
-                'integration_method': 'survival',
                 'error': str(e)
             }
             results.append(result)

--- a/tests/test_temporal_ml_simulation.py
+++ b/tests/test_temporal_ml_simulation.py
@@ -97,8 +97,6 @@ class TestTemporalMLPredictions(unittest.TestCase):
 
         # Check that method produces valid results
         self.assertEqual(len(preds), self.n_patients)
-        self.assertIn('integration_method', metrics)
-        self.assertEqual(metrics['integration_method'], 'survival')
 
         # Check that predictions are valid probabilities
         self.assertTrue(np.all(preds >= 0))
@@ -214,23 +212,18 @@ class TestMLPredictionSimulatorTemporal(unittest.TestCase):
             prediction_window_length=6
         )
 
-        # Verify integration method is correctly set to survival
-        self.assertEqual(info['integration_method'], 'survival')
-
         # Check outputs
         self.assertEqual(preds.shape, (self.n_patients,))
         self.assertEqual(binary.shape, (self.n_patients,))
         self.assertIsInstance(info, dict)
 
         # Check info content
-        self.assertIn('integration_method', info)
         self.assertIn('window_start', info)
         self.assertIn('window_length', info)
         self.assertIn('temporal_correlation', info)
         self.assertIn('integration_correlation', info)
 
         # Verify values
-        self.assertEqual(info['integration_method'], 'survival')
         self.assertEqual(info['window_start'], 8)
         self.assertEqual(info['window_length'], 6)
 
@@ -260,8 +253,6 @@ class TestMLPredictionSimulatorTemporal(unittest.TestCase):
         self.assertTrue(np.all(preds2 >= 0) and np.all(preds2 <= 1))
 
         # Info should be consistently structured
-        self.assertEqual(info1['integration_method'], 'survival')
-        self.assertEqual(info2['integration_method'], 'survival')
         self.assertEqual(info1['window_start'], info2['window_start'])
         self.assertEqual(info1['window_length'], info2['window_length'])
 
@@ -442,7 +433,7 @@ class TestTemporalMLBenchmarking(unittest.TestCase):
 
         # Check expected columns exist
         expected_cols = [
-            'config_id', 'start_time', 'window_length', 'integration_method',
+            'config_id', 'start_time', 'window_length',
             'temporal_sensitivity', 'temporal_ppv', 'temporal_f1',
             'static_sensitivity', 'static_ppv', 'static_f1'
         ]
@@ -455,8 +446,6 @@ class TestTemporalMLBenchmarking(unittest.TestCase):
             row = results_df.iloc[i]
             self.assertEqual(row['start_time'], config['start_time'])
             self.assertEqual(row['window_length'], config['window_length'])
-            # Integration method should always be 'survival' now
-            self.assertEqual(row['integration_method'], 'survival')
 
     def test_benchmark_comparison_temporal_vs_static(self):
         """Test that benchmark compares temporal vs static approaches."""
@@ -474,9 +463,7 @@ class TestTemporalMLBenchmarking(unittest.TestCase):
             random_seed=42
         )
 
-        # Verify integration method is always set to survival
         row = results_df.iloc[0]
-        self.assertEqual(row['integration_method'], 'survival')
 
         # Both temporal and static should have reasonable performance
         self.assertGreater(row['temporal_sensitivity'], 0.1)


### PR DESCRIPTION
## Summary
Removes hardcoded `'integration_method': 'survival'` entries across ml_simulation.py to improve code clarity since only one integration method is implemented.

## Changes Made
- **Source code cleanup**: Removed `integration_method` from 4 locations in `src/pop_ml_simulator/ml_simulation.py`:
  - `MLPredictionSimulator.generate_temporal_predictions()` 
  - `generate_temporal_ml_predictions()`
  - `benchmark_temporal_ml_performance()` (success and error cases)
- **Documentation updates**: Updated docstring and inline comment to explicitly state survival-based integration
- **Test updates**: Removed 8 integration_method test assertions from `tests/test_temporal_ml_simulation.py`
- **Test cleanup**: Removed `integration_method` from expected_columns list in benchmarking tests

## Validation
- ✅ All 44 core tests pass (0.56s execution time)
- ✅ All flake8 checks pass
- ✅ No functional changes to integration logic - only removed hardcoded constants
- ✅ Return dictionary structures maintained (minus the redundant key)

## Result
Cleaner, more focused code that describes what it actually does rather than using generic placeholders. The code now explicitly states it uses survival-based integration instead of pretending multiple methods exist.

Fixes #51

🤖 Generated with [Claude Code](https://claude.ai/code)